### PR TITLE
The UI element has changed from title to Title

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -112,7 +112,16 @@
 				<key>escaping</key>
 				<integer>68</integer>
 				<key>script</key>
-				<string>tell application "System Events"	tell process "SystemUIServer"		try			click (menu bar item 1 of menu bar 1 whose description contains "Displays")			click (menu item 1 of menu 1 of result whose title contains "iPad")		on error			display dialog "Cannot find any iPads available right now"		end try	end tellend tell</string>
+				<string>tell application "System Events"
+	tell process "SystemUIServer"
+		try
+			click (menu bar item 1 of menu bar 1 whose description contains "Displays")
+			click (menu item 1 of menu 1 of result whose Title contains "iPad")
+		on error
+			display dialog "Cannot find any iPads available right now"
+		end try
+	end tell
+end tell</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>


### PR DESCRIPTION
The workflow stopped working due to the UI element not being able to find "title" because it has changed to "Title" with a capital T. This will fix the issue of not finding iPads